### PR TITLE
1.修复自定义指令bug；2.修复用户设置重置bug

### DIFF
--- a/js/modules/templateManager.js
+++ b/js/modules/templateManager.js
@@ -83,6 +83,11 @@ Always respond in 中文。`
      * @returns {string} 模板内容
      */
     getActiveTemplateContent() {
+        // 如果当前选择的是默认模板，但是有自定义指令，则使用自定义指令
+        if (this.activeTemplate === 'default' && this.customPrompt && this.customPrompt.trim() !== '') {
+            return this.customPrompt;
+        }
+        
         if (this.activeTemplate === 'custom' && this.customPrompt) {
             return this.customPrompt;
         }


### PR DESCRIPTION
1.自定义优化指令会覆盖默认优化模板，用户点击应用设置之后，默认优化模板对应的按钮的文字应该从“默认优化”变成“自定义”，悬停提示应该随之变化，而且应该确保用户输入会被自定义优化提示处理
2.每次启动页面，都应该正确地初始化一些默认的设置，比如：
a. API provider为gemini；
b. 高级设置里默认没有自定义指令，默认不开启多轮优化